### PR TITLE
Set error message font size

### DIFF
--- a/player.css
+++ b/player.css
@@ -125,6 +125,7 @@
     justify-content: center;
     flex-direction: column;
     height: 100px;
+    font-size: 14px;
 }
 .error > h3 {
     margin: 0;


### PR DESCRIPTION
The current default font size causes the text to get outside the player UI in some web browsers.